### PR TITLE
new URL Format

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,6 +8,6 @@ const proxy = require('./src/proxy')
 const PORT = process.env.PORT || 8080
 
 app.enable('trust proxy')
-app.get('/', authenticate, params, proxy)
 app.get('/favicon.ico', (req, res) => res.status(204).end())
+app.get('*', authenticate, params, proxy)
 app.listen(PORT, () => console.log(`Listening on ${PORT}`))

--- a/src/params.js
+++ b/src/params.js
@@ -2,7 +2,7 @@ const DEFAULT_QUALITY = 40
 
 function params(req, res, next) {
   if (req._parsedUrl.pathname == "/") {
-    // old URL format /?url=https%3A%2F%2Fhost%2Fpath%2Ffile.jpg&jpeg=0&bw=0&l=50
+    // old URL format /?url=https%3A%2F%2Fhost%2Fpath%2Ffile.jpg%3FqueryString&jpeg=0&bw=0&l=50
     let url = req.query.url
     if (Array.isArray(url)) url = url.join('&url=')
     if (!url) return res.end('bandwidth-hero-proxy')
@@ -14,10 +14,13 @@ function params(req, res, next) {
     req.params.quality = parseInt(req.query.l, 10) || DEFAULT_QUALITY
   }
   else {
-    // new URL format /https/host/path/file.jpg.c50.webp
-    let match = req.url.match(/^\/(\w+)\/(.*?).([bc])(\d{1,3})\.(\w+)$/)
+    // new URL format /https/host/path/file.jpg.c50.webp?queryString
+    const match = req.url.match(/^\/(\w+)\/(.*?).([bc])(\d{1,3})\.(\w+)(\?.*)?$/);
     if (match) {
-      req.params.url = match[1] + "://" + match[2];
+      req.params.url = match[1] + "://" + match[2]; // protocol + host + path
+      if(match[6]) {
+        req.params.url += match[6]; // query string
+      }
       req.params.grayscale = (match[3] == "b");
       req.params.quality = parseInt(match[4], 10) || DEFAULT_QUALITY;
       req.params.webp = (match[5] == "webp");

--- a/src/params.js
+++ b/src/params.js
@@ -1,16 +1,28 @@
 const DEFAULT_QUALITY = 40
 
 function params(req, res, next) {
-  let url = req.query.url
-  if (Array.isArray(url)) url = url.join('&url=')
-  if (!url) return res.end('bandwidth-hero-proxy')
+  if (req._parsedUrl.pathname == "/") {
+    // old URL format /?url=https%3A%2F%2Fhost%2Fpath%2Ffile.jpg&jpeg=0&bw=0&l=50
+    let url = req.query.url
+    if (Array.isArray(url)) url = url.join('&url=')
+    if (!url) return res.end('bandwidth-hero-proxy')
 
-  url = url.replace(/http:\/\/1\.1\.\d\.\d\/bmi\/(https?:\/\/)?/i, 'http://')
-  req.params.url = url
-  req.params.webp = !req.query.jpeg
-  req.params.grayscale = req.query.bw != 0
-  req.params.quality = parseInt(req.query.l, 10) || DEFAULT_QUALITY
-
+    url = url.replace(/http:\/\/1\.1\.\d\.\d\/bmi\/(https?:\/\/)?/i, 'http://')
+    req.params.url = url
+    req.params.webp = !req.query.jpeg
+    req.params.grayscale = req.query.bw != 0
+    req.params.quality = parseInt(req.query.l, 10) || DEFAULT_QUALITY
+  }
+  else {
+    // new URL format /https/host/path/file.jpg.c50.webp
+    let match = req.url.match(/^\/(\w+)\/(.*?).([bc])(\d{1,3})\.(\w+)$/)
+    if (match) {
+      req.params.url = match[1] + "://" + match[2];
+      req.params.grayscale = (match[3] == "b");
+      req.params.quality = parseInt(match[4], 10) || DEFAULT_QUALITY;
+      req.params.webp = (match[5] == "webp");
+    }
+  }
   next()
 }
 

--- a/src/params.js
+++ b/src/params.js
@@ -14,16 +14,34 @@ function params(req, res, next) {
     req.params.quality = parseInt(req.query.l, 10) || DEFAULT_QUALITY
   }
   else {
-    // new URL format /https/host/path/file.jpg.c50.webp?queryString
-    const match = req.url.match(/^\/(\w+)\/(.*?).([bc])(\d{1,3})\.(\w+)(\?.*)?$/);
+    // new URL format /k=v&k2=v2/https/host/path/file.jpg.c50.webp?queryString
+    const match = req.url.match(/^(?:\/([^/]+?=[^/]+))?\/(\w+)\/(.*?).([bc])(\d{1,3})\.(\w+)(\?.*)?$/);
     if (match) {
-      req.params.url = match[1] + "://" + match[2]; // protocol + host + path
-      if(match[6]) {
-        req.params.url += match[6]; // query string
+      
+      let queryObj = {};
+      if (match[1]) {
+        // parse internal query string before protocol
+        let input = match[1];
+        const re = /([^?&=]+)(?:=([^&]+))?/g;
+        let match2;
+        while (match2 = re.exec(input)) {
+          queryObj[match2[1]] = decodeURIComponent(match2[2]);
+        }
       }
-      req.params.grayscale = (match[3] == "b");
-      req.params.quality = parseInt(match[4], 10) || DEFAULT_QUALITY;
-      req.params.webp = (match[5] == "webp");
+
+      // reconstruct original URL
+      req.params.url = match[2] + "://" + match[3]; // protocol + host + path
+      if (queryObj.appendPath) {
+        req.params.url += queryObj.appendPath;
+      }
+      if(match[7]) {
+        req.params.url += match[7]; // query string
+      }
+      
+      // set compression parameters
+      req.params.grayscale = (match[4] == "b");
+      req.params.quality = parseInt(match[5], 10) || DEFAULT_QUALITY;
+      req.params.webp = (match[6] == "webp");
     }
   }
   next()


### PR DESCRIPTION
Forwarded the PR at upstream to my fork

> old format /?url=https%3A%2F%2Fhost%2Fpath%2Ffile.jpg&jpeg=0&bw=0&l=50
> new format /https/host/path/file.jpg.c50.webp
> solve issue ayastreb/bandwidth-hero#22
> new format must be supported by server (bandwidth-hero-proxy)